### PR TITLE
Fix the recipe/ingredient/category selectors

### DIFF
--- a/flyingcracker/config/urls.py
+++ b/flyingcracker/config/urls.py
@@ -14,12 +14,12 @@ urlpatterns = [
     # Application URLs
     re_path(r'^cam/', include('cam.urls')),
     re_path(r'^(?P<recipe_type>drink|food)/', include('food.urls')),
-    re_path(r'^ingredient/(?P<slug>[\w_-]+)/$', food_views.foodstuff_detail, name='ingredient-detail'),
-    # deprecated urls
-    re_path(r'^(?P<recipe_type>cocktail)/', include('food.redirect_urls')),
     re_path(r'^weatherstation/', include('weatherstation.urls')),
     re_path(r'^weather/', include('weather.urls')),
     re_path(r'^', include('home.urls')),
+
+    # redirect old urls
+    re_path(r'^(?P<recipe_type>cocktail)/', include('food.redirect_urls')),
 ]
 
 if pattern_views and settings.DEBUG:

--- a/flyingcracker/food/templates/food/category_list.html
+++ b/flyingcracker/food/templates/food/category_list.html
@@ -1,0 +1,27 @@
+{% extends "cocktail.html" %}
+
+{% block body %}
+<div class="cocktail">
+    <div class="box">
+        <div class="header">
+            <div class="title">
+                {{ category|capfirst }} {{ recipe_type|capfirst }} Recipes
+            </div>
+        </div>
+    {% if matching_recipes %}
+        <div class="bd">
+        {% for recipe in matching_recipes %}
+            <div class="yui-gd">
+                <div class="yui-u first"><a href="{% url 'food:recipe-detail' recipe_type=recipe_type slug=recipe.slug %}">{{ recipe.title }}</a></div>
+                <div class="yui-u">{{ recipe.teaser }}</div>
+            </div>
+        {% endfor %}
+        </div>
+    {% else %}
+        <p>No {{ recipe_type }} recipes in the database.</p>
+    {% endif %}
+    <br />
+    {% include "food/food_select.html" %}
+    </div>
+</div>
+{% endblock %}

--- a/flyingcracker/food/templates/food/food_select.html
+++ b/flyingcracker/food/templates/food/food_select.html
@@ -19,7 +19,7 @@
                 <select id="id-foodstuff" class="selectLink">
                     <option value="">Select an ingredient</option>
                     {% for item in foodstuff_list %}
-                    <option value="{% url 'ingredient-detail' slug=item.slug %}">
+                    <option value="{% url 'food:ingredient-detail' recipe_type=recipe_type slug=item.slug %}">
                         {{ item.title }}
                     </option>
                     {% endfor %}
@@ -32,7 +32,7 @@
                 <select id="id-category" class="selectLink">
                     <option value="">Select a category</option>
                     {% for item in category_list %}
-                    <option value="{% url 'food:category-list' recipe_type=recipe_type slug=item.slug %}">
+                    <option value="{% url 'food:category-detail' recipe_type=recipe_type slug=item.slug %}">
                         {{ item.title }}
                     </option>
                     {% endfor %}
@@ -44,21 +44,21 @@
 
 <script type="text/javascript">
 
-function initSelects() {
-    YAHOO.util.Event.addListener(this, "change", newSelect);
-};
+    function initSelects() {
+        YAHOO.util.Event.addListener(this, "change", newSelect);
+    };
 
-function newSelect(e) {
-    var t = YAHOO.util.Event.getTarget(e);
+    function newSelect(e) {
+        var t = YAHOO.util.Event.getTarget(e);
 
-    if (t.selectedIndex != 0) {
-        t.parentElement.submit();
-        YAHOO.util.Event.preventDefault(e);
-    }
-};
+        if (t.selectedIndex != 0) {
+            window.location.href = t.value;
+            YAHOO.util.Event.preventDefault(e);
+        }
+    };
 
-YAHOO.util.Event.onAvailable('id-recipe', initSelects);
-YAHOO.util.Event.onAvailable('id-foodstuff', initSelects);
-YAHOO.util.Event.onAvailable('id-category', initSelects);
+    YAHOO.util.Event.onAvailable('id-recipe', initSelects);
+    YAHOO.util.Event.onAvailable('id-foodstuff', initSelects);
+    YAHOO.util.Event.onAvailable('id-category', initSelects);
 
 </script>

--- a/flyingcracker/food/templates/food/foodstuff_detail.html
+++ b/flyingcracker/food/templates/food/foodstuff_detail.html
@@ -16,17 +16,20 @@
         {% endif %}
         </div>
 
-        {% if recipes %}
+        {% if matching_recipes %}
         <br />
         <div class="title">Recipes</div>
         <ul>
-        {% for r in recipes %}
-            <li><a href="{{ r.get_absolute_url }}">{{ r }}</a></li>
-        {% endfor %}
+            {% for recipe in matching_recipes %}
+            <li><a href="{{ recipe.get_absolute_url }}">{{ recipe }}</a></li>
+            {% endfor %}
          </ul>
         {% else %}
             No recipes use {{ foodstuff }}
         {% endif %}
+        <div>
+            {% include "food/food_select.html" %}
+        </div>
     </div> <!-- box -->
 </div> <!-- cocktail -->
 {% endblock %}

--- a/flyingcracker/food/templates/food/foodstuff_list.html
+++ b/flyingcracker/food/templates/food/foodstuff_list.html
@@ -8,17 +8,17 @@
                 All {{ recipe_type|capfirst }} Ingredients
             </div>
         </div>
-{% if all_foodstuff %}
-    <table>
-    {% for foodstuff in all_foodstuff %}
-        <tr>
-            <td><a href="{% url 'ingredient-detail' slug=foodstuff.slug %}">{{ foodstuff }}</a></td>
-        </tr>
-    {% endfor %}
-    </table>
-{% else %}
-    No ingredients in the database.
-{% endif %}
+        {% if all_foodstuff %}
+        <table>
+            {% for foodstuff in all_foodstuff %}
+            <tr>
+                <td><a href="{% url 'food:ingredient-detail' recipe_type=recipe_type slug=foodstuff.slug %}">{{ foodstuff }}</a></td>
+            </tr>
+            {% endfor %}
+        </table>
+        {% else %}
+        No ingredients in the database.
+        {% endif %}
     </div>
 
     <div class="box">
@@ -27,4 +27,3 @@
 </div>
 
 {% endblock %}
-

--- a/flyingcracker/food/templates/food/foodstuff_list.html
+++ b/flyingcracker/food/templates/food/foodstuff_list.html
@@ -12,7 +12,8 @@
         <table>
             {% for foodstuff in all_foodstuff %}
             <tr>
-                <td><a href="{% url 'food:ingredient-detail' recipe_type=recipe_type slug=foodstuff.slug %}">{{ foodstuff }}</a></td>
+                <td><a href="{% url 'food:ingredient-detail' recipe_type=recipe_type slug=foodstuff.slug %}">{{
+                        foodstuff }}</a></td>
             </tr>
             {% endfor %}
         </table>

--- a/flyingcracker/food/templates/food/iphone/food_select.html
+++ b/flyingcracker/food/templates/food/iphone/food_select.html
@@ -30,29 +30,29 @@
 
 <script type="text/javascript">
 
-function loadSelect(type, args) {
-    snippet_navigation (args[0]);
-};
+    function loadSelect(type, args) {
+        snippet_navigation(args[0]);
+    };
 
-selectChange = new YAHOO.util.CustomEvent('select change');
-selectChange.subscribe(loadSelect);
+    selectChange = new YAHOO.util.CustomEvent('select change');
+    selectChange.subscribe(loadSelect);
 
-function initSelects() {
-    YAHOO.util.Event.addListener(this, "change", newSelect);
-};
+    function initSelects() {
+        YAHOO.util.Event.addListener(this, "change", newSelect);
+    };
 
-function newSelect(e) {
-    var t = YAHOO.util.Event.getTarget(e);
+    function newSelect(e) {
+        var t = YAHOO.util.Event.getTarget(e);
 
-    if (t.selectedIndex != 0) {
-        var value = t.value;
-        t.selectedIndex = 0;    // reset the index
-        selectChange.fire(value);
-        YAHOO.util.Event.preventDefault(e);
-    }
-};
+        if (t.selectedIndex != 0) {
+            var value = t.value;
+            t.selectedIndex = 0;    // reset the index
+            selectChange.fire(value);
+            YAHOO.util.Event.preventDefault(e);
+        }
+    };
 
-YAHOO.util.Event.onAvailable('id-cocktail', initSelects);
-YAHOO.util.Event.onAvailable('id-foodstuff', initSelects);
+    YAHOO.util.Event.onAvailable('id-cocktail', initSelects);
+    YAHOO.util.Event.onAvailable('id-foodstuff', initSelects);
 
 </script>

--- a/flyingcracker/food/templates/food/iphone/recipe_snippet.html
+++ b/flyingcracker/food/templates/food/iphone/recipe_snippet.html
@@ -5,17 +5,17 @@
     <div class="yui-b" id="recipe-title">
         {{ recipe.title }}
     </div>
-{% for i in ingredients %}
+    {% for i in ingredients %}
     <div class="yui-gf">
         <div id="ingredient">
             <div class="yui-u first i-qty">{{ i.quantity }}</div>
             <div class="yui-u">
-                <span class="i-title"><a href="{% url 'ingredient-detail' slug=i.slug %}">{{ i.title }}</a></span>
+                <span class="i-title"><a href="{% url 'ingredient-detail' recipe_type=recipe_type slug=i.slug %}">{{ i.title }}</a></span>
                 <span class="i-modifier">{{ i.modifier }}</span>
             </div>
         </div>
     </div>
-{% endfor %}
+    {% endfor %}
     <div class="yui-b" id="recipe-directions">
         {{ recipe.directions|apply_markup:"markdown" }}
     </div>

--- a/flyingcracker/food/templates/food/recipe_detail.html
+++ b/flyingcracker/food/templates/food/recipe_detail.html
@@ -2,46 +2,46 @@
 {% load markup_tags %}
 
 {% block body %}
-	<div class="cocktail">
-		<div class="box">
-			<div class="header">
-				<div class="title">
-					{{ recipe }}
-				</div>
+<div class="cocktail">
+	<div class="box">
+		<div class="header">
+			<div class="title">
+				{{ recipe }}
 			</div>
+		</div>
 
-			<table>
-				{% for i in ingredients %}
-				<tr>
-					<td><span class="qty">{{ i.quantity }}</span></td>
-					<td><span class="name">
-						<a href="{% url 'ingredient-detail' slug=i.slug %}">
-						{{ i.title }}</a>
+		<table>
+			{% for i in ingredients %}
+			<tr>
+				<td><span class="qty">{{ i.quantity }}</span></td>
+				<td><span class="name">
+						<a href="{% url 'food:ingredient-detail' recipe_type=recipe_type slug=i.slug %}">
+							{{ i.title }}</a>
 					</span></td>
-					<td><span class="modifier">{{ i.modifier }}</span></td>
-				</tr>
-				{% endfor %}
-			</table>
+				<td><span class="modifier">{{ i.modifier }}</span></td>
+			</tr>
+			{% endfor %}
+		</table>
 
-			<div class="directions">
-				{{ recipe.directions|apply_markup:"markdown" }}
-			</div>
-			{% if recipe.description %}
-			<div class="description">
-				{{ recipe.description|apply_markup:"markdown" }}
-			</div>
-			{% endif %}
-			{% if recipe.credit %}
-			<div class="credit">
-				{{ recipe.credit|apply_markup:"markdown" }}
-			</div>
-			{% endif %}
-			<div class="pubdate">
-				added {{ recipe.pub_date|date:"F j, Y" }}
-			</div>
-			<br />
-{% include "food/food_select.html" %}
-		</div> <!-- box -->
-	</div> <!-- cocktail -->
+		<div class="directions">
+			{{ recipe.directions|apply_markup:"markdown" }}
+		</div>
+		{% if recipe.description %}
+		<div class="description">
+			{{ recipe.description|apply_markup:"markdown" }}
+		</div>
+		{% endif %}
+		{% if recipe.credit %}
+		<div class="credit">
+			{{ recipe.credit|apply_markup:"markdown" }}
+		</div>
+		{% endif %}
+		<div class="pubdate">
+			added {{ recipe.pub_date|date:"F j, Y" }}
+		</div>
+		<div>
+			{% include "food/food_select.html" %}
+		</div>
+	</div> <!-- box -->
+</div> <!-- cocktail -->
 {% endblock %}
-

--- a/flyingcracker/food/templates/food/recipe_list.html
+++ b/flyingcracker/food/templates/food/recipe_list.html
@@ -8,9 +8,9 @@
                 All {% if category %}{{ category|capfirst }} {% endif %}{{ recipe_type|capfirst }} Recipes
             </div>
         </div>
-    {% if all_recipes %}
+    {% if matching_recipes %}
         <div class="bd">
-        {% for recipe in all_recipes %}
+        {% for recipe in matching_recipes %}
             <div class="yui-gd">
                 <div class="yui-u first"><a href="{% url 'food:recipe-detail' recipe_type=recipe_type slug=recipe.slug %}">{{ recipe.title }}</a></div>
                 <div class="yui-u">{{ recipe.teaser }}</div>
@@ -20,10 +20,8 @@
     {% else %}
         <p>No {{ recipe_type }} recipes in the database.</p>
     {% endif %}
-    </div>
-
-    <div class="box">
-        <a href="{% url 'food:ingredient-list' recipe_type=recipe_type %}">All {{ recipe_type|capfirst }} Ingredients</a>
+    <br />
+    {% include "food/food_select.html" %}
     </div>
 </div>
 {% endblock %}

--- a/flyingcracker/food/templates/food/recipe_list.html
+++ b/flyingcracker/food/templates/food/recipe_list.html
@@ -5,7 +5,7 @@
     <div class="box">
         <div class="header">
             <div class="title">
-                All {% if category %}{{ category|capfirst }} {% endif %}{{ recipe_type|capfirst }} Recipes
+                All {{ recipe_type|capfirst }} Recipes
             </div>
         </div>
     {% if matching_recipes %}

--- a/flyingcracker/food/urls.py
+++ b/flyingcracker/food/urls.py
@@ -4,9 +4,9 @@ from . import views
 
 app_name = 'food'
 urlpatterns = [
-    re_path(r'^ingredients/$', views.foodstuff_list, name='ingredient-list'),
-    re_path(r'^i/(?P<slug>[\w_-]+)/$', views.foodstuff_detail, name='ingredient-detail'),
     re_path(r'^c/(?P<slug>[\w_-]+)/$', views.category_detail, name='category-detail'),
+    re_path(r'^i/(?P<slug>[\w_-]+)/$', views.foodstuff_detail, name='ingredient-detail'),
+    re_path(r'^ingredients/$', views.foodstuff_list, name='ingredient-list'),
     re_path(r'^(?P<slug>[\w_-]+)/$', views.recipe_detail, name='recipe-detail'),
     re_path(r'^$', views.recipe_list, name='recipe-list'),
 ]

--- a/flyingcracker/food/urls.py
+++ b/flyingcracker/food/urls.py
@@ -5,7 +5,8 @@ from . import views
 app_name = 'food'
 urlpatterns = [
     re_path(r'^ingredients/$', views.foodstuff_list, name='ingredient-list'),
-    re_path(r'^c/(?P<slug>[\w_-]+)/$', views.category_list, name='category-list'),
+    re_path(r'^i/(?P<slug>[\w_-]+)/$', views.foodstuff_detail, name='ingredient-detail'),
+    re_path(r'^c/(?P<slug>[\w_-]+)/$', views.category_detail, name='category-detail'),
     re_path(r'^(?P<slug>[\w_-]+)/$', views.recipe_detail, name='recipe-detail'),
     re_path(r'^$', views.recipe_list, name='recipe-list'),
 ]

--- a/flyingcracker/food/views.py
+++ b/flyingcracker/food/views.py
@@ -184,7 +184,7 @@ def category_detail(request, recipe_type, slug):
         'matching_recipes': category_recipes,
         'recipe_type': recipe_type,
     }
-    return render(request, 'food/recipe_list.html', context)
+    return render(request, 'food/category_list.html', context)
 
 
 def get_all_lists(recipe_type):

--- a/flyingcracker/food/views.py
+++ b/flyingcracker/food/views.py
@@ -2,7 +2,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.views.generic.base import RedirectView
-
+from django.db.models.functions import Lower
 from .models import Category, Foodstuff, Recipe
 
 
@@ -36,16 +36,18 @@ class IngredientListRedirectView(FoodRedirectView):
 
 class CategoryListRedirectView(FoodRedirectView):
 
-    pattern_name = 'food:category-list'
+    pattern_name = 'food:category-detail'
 
 
 def recipe_list(request, recipe_type=""):
-    all_recipes, all_foodstuff = get_all_lists(recipe_type)
+    all_recipes, all_foodstuff, all_categories = get_all_lists(recipe_type)
+
     agent = request.META.get('HTTP_USER_AGENT')
     if (agent and agent.find('iPhone') != -1) or 'iphone' in request.GET:
         context = {
             'recipe_list': all_recipes,
             'foodstuff_list': all_foodstuff,
+            'category_list': all_categories,
             'recipe_type': recipe_type,
         }
         if 'snippet' in request.GET:
@@ -56,7 +58,10 @@ def recipe_list(request, recipe_type=""):
             return render(request, 'food/iphone/recipe_initial.html', context)
     else:
         context = {
-            'all_recipes': all_recipes,
+            'recipe_list': all_recipes,
+            'foodstuff_list': all_foodstuff,
+            'category_list': all_categories,
+            'matching_recipes': all_recipes,
             'recipe_type': recipe_type,
         }
         return render(request, 'food/recipe_list.html', context)
@@ -65,8 +70,7 @@ def recipe_list(request, recipe_type=""):
 def recipe_detail(request, slug, recipe_type=""):
     r = get_object_or_404(Recipe, slug=slug)
 
-    all_recipes, all_foodstuff = get_all_lists(recipe_type)
-    all_categories = Category.objects.all().order_by('title')
+    all_recipes, all_foodstuff, all_categories = get_all_lists(recipe_type)
 
     # get ingredients for this recipe
     ingredient_list = []
@@ -95,12 +99,14 @@ def recipe_detail(request, slug, recipe_type=""):
 
 
 def foodstuff_list(request, recipe_type=""):
-    all_recipes, all_foodstuff = get_all_lists(recipe_type)
+    all_recipes, all_foodstuff, all_categories = get_all_lists(recipe_type)
+
     agent = request.META.get('HTTP_USER_AGENT')
     if (agent and agent.find('iPhone') != -1) or 'iphone' in request.GET:
         context = {
             'recipe_list': all_recipes,
             'foodstuff_list': all_foodstuff,
+            'category_list': all_categories,
             'recipe_type': recipe_type,
         }
         if 'snippet' in request.GET:
@@ -111,24 +117,32 @@ def foodstuff_list(request, recipe_type=""):
             return render(request, 'food/iphone/foodstuff_initial.html', context)
     else:
         context = {
+            'recipe_list': all_recipes,
+            'foodstuff_list': all_foodstuff,
+            'category_list': all_categories,
             'all_foodstuff': all_foodstuff,
             'recipe_type': recipe_type,
         }
         return render(request, 'food/foodstuff_list.html', context)
 
 
-def foodstuff_detail(request, slug, recipe_type=""):
+def foodstuff_detail(request, recipe_type, slug):
     f = get_object_or_404(Foodstuff, slug=slug)
 
-    recipe_list = Recipe.objects.filter(ingredients__foodstuff=f).order_by('rclass', 'title')
+    all_recipes, all_foodstuff, all_categories = get_all_lists(recipe_type)
+
+    recipe_list = Recipe.objects.filter(
+        ingredients__foodstuff=f,
+        rclass=db_recipe_type(recipe_type)
+    ).order_by(Lower('title'))
     agent = request.META.get('HTTP_USER_AGENT')
     if (agent and agent.find('iPhone') != -1) or 'iphone' in request.GET:
-        all_recipes, all_foodstuff = get_all_lists(recipe_type)
         context = {
             'recipe_list': all_recipes,
             'foodstuff_list': all_foodstuff,
+            'category_list': all_categories,
             'foodstuff': f,
-            'recipes': recipe_list,
+            'matching_recipes': recipe_list,
         }
         if 'snippet' in request.GET:
             return render(request, 'food/iphone/foodstuff_snippet.html', context)
@@ -138,39 +152,50 @@ def foodstuff_detail(request, slug, recipe_type=""):
             return render(request, 'food/iphone/foodstuff_initial.html', context)
     else:
         context = {
+            'recipe_list': all_recipes,
+            'foodstuff_list': all_foodstuff,
+            'category_list': all_categories,
+
             'foodstuff': f,
-            'recipes': recipe_list,
+            'matching_recipes': recipe_list,
+            'recipe_type': recipe_type,
         }
         return render(request, 'food/foodstuff_detail.html', context)
 
 
-def category_list(request, recipe_type, slug):
+def category_detail(request, recipe_type, slug):
     try:
         category = Category.objects.get(slug=slug)
     except Category.DoesNotExist:
         return HttpResponseRedirect(
             reverse('food:recipe-list', kwargs={'recipe_type': recipe_type})
         )
-
     category_recipes = Recipe.objects.filter(
         rclass=db_recipe_type(recipe_type), categories=category
-    )
+    ).order_by(Lower('title'))
+
+    all_recipes, all_foodstuff, all_categories = get_all_lists(recipe_type)
     context = {
-        'all_recipes': category_recipes,
-        'recipe_type': recipe_type,
+        'recipe_list': all_recipes,
+        'foodstuff_list': all_foodstuff,
+        'category_list': all_categories,
+
         'category': category,
+        'matching_recipes': category_recipes,
+        'recipe_type': recipe_type,
     }
     return render(request, 'food/recipe_list.html', context)
 
 
 def get_all_lists(recipe_type):
-    all_recipes = Recipe.objects.filter(rclass=db_recipe_type(recipe_type)).order_by('title')
+    all_recipes = Recipe.objects.filter(rclass=db_recipe_type(recipe_type)).order_by(Lower('title'))
     all_foodstuffs = (
         Foodstuff.objects.filter(ingredients__recipe__rclass=db_recipe_type(recipe_type))
         .distinct()
-        .order_by('title')
+        .order_by(Lower('title'))
     )
-    return all_recipes, all_foodstuffs
+    all_categories = Category.objects.all().order_by('title')
+    return all_recipes, all_foodstuffs, all_categories
 
 
 def db_recipe_type(recipe_type):


### PR DESCRIPTION
* Move ingredient detail underneath "food/drink" urlpath to `food` app.
* Improve url naming. "category-list" is not a list of categories, it's detail on the category with a list of matching recipes. Use "category-detail" instead.
* Show Recipe / Ingredient / Category selectors on the bottom of most food pages.
* Add new category_list.html" template.